### PR TITLE
Add run_depend to install libgazebo_ros_control.so.

### DIFF
--- a/tetris_gazebo/package.xml
+++ b/tetris_gazebo/package.xml
@@ -16,6 +16,7 @@
   <run_depend>rosbash</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>gazebo_ros_control</run_depend>
   <run_depend>robot_state_publisher</run_depend>
 
   <export>


### PR DESCRIPTION
http://answers.ros.org/question/187417/problem-running-gazebo-failed-to-load-plugin-libgazebo_ros_controlso/

Not sure though if adding dependency to the very downstream package like hakuto. Shouldn't this better be handled somewhere upstream?
