### PR TITLE
add rosbridge_websocket.launch to demo.launch

### DIFF
--- a/tetris_launch/launch/demo.launch
+++ b/tetris_launch/launch/demo.launch
@@ -4,6 +4,7 @@
   <include file="$(find tetris_gazebo)/launch/tetris_world.launch" >
     <arg name="gui" value="$(arg gui)" />
   </include>
+  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
   <group if="$(arg kbteleop)">
     <node pkg="teleop_twist_keyboard" name="teleop_twist_keyboard" type="teleop_twist_keyboard.py" launch-prefix="xterm -e" >
       <remap from="cmd_vel" to="/tetris/cmd_vel" />


### PR DESCRIPTION
do you have any reason that you did not include this in demo.launch nor https://github.com/k-okada/hakuto/blob/add_supervisor/tetris_launch/doc/sysadmin.rst
```
Prepare joystick keypad (for tele-operation)
Tele-operation is done by using keyboardteleopjs that accepts command input from the keyboard through web browser. Put a joystick.html file under the docroot of your web server. In this document we use /var/www/ for apache in this document.

$ cp `rospack find tetris_launch`/www/joystick.html /var/www/
You might need to edit the file using your web server's IP address, and the name of Twist topic. Do that by following the tutorial for keyboard teleop.
```